### PR TITLE
Switch apply to create

### DIFF
--- a/roles/import-from-url/tasks/provision.yml
+++ b/roles/import-from-url/tasks/provision.yml
@@ -33,7 +33,7 @@
     msg: "{{ debug_out.stdout }}"
 
 - name: Provision PVC
-  command: "oc apply -f /tmp/pvc.yml"
+  command: "oc create -f /tmp/pvc.yml"
 
 - name: Set pvc_name
   set_fact:


### PR DESCRIPTION
- Switched PVC creation from apply to create to avoid any
  potential race conditions were two imports with the same
  name are started together, and the second one could over write
  the first one. With a create the second will fail because it
  can't create the PVC because it already exists.

Signed-off-by: Alexander Wels <awels@redhat.com>