### PR TITLE
Update import monitoring annotation

### DIFF
--- a/roles/import-from-url/defaults/main.yml
+++ b/roles/import-from-url/defaults/main.yml
@@ -5,3 +5,5 @@ disk_size_gb: 0  # auto-detect
 disk_bus_by_os_type:
   linux: virtio
   windows: sata
+import_status_path: .metadata.annotations.cdi\.kubevirt\.io/storage\.import\.pod\.phase
+pvc_status_path: .status.phase

--- a/roles/import-from-url/tasks/provision.yml
+++ b/roles/import-from-url/tasks/provision.yml
@@ -45,11 +45,6 @@
 - name: Provision PVC
   command: "oc create -f /tmp/pvc.yml"
 
-- name: set pvc status jsonpath selectors
-  set_fact:
-    import_status_path: .metadata.annotations.kubevirt\.io/storage\.import\.pod\.phase
-    pvc_status_path: .status.phase
-
 - Name: Check PVC bound status
   command: "oc get pvc {{ vm_name }}-disk-01 -o jsonpath='{ {{pvc_status_path}} }'"
   register: pvc_bound_status


### PR DESCRIPTION
The import monitoring annotation changed from:
    .metadata.annotations.kubevirt\.io/storage\.import\.pod\.phase
to:
    .metadata.annotations.cdi\.kubevirt\.io/storage\.import\.pod\.phase

Also, we don't need to dynamically use set_fact to set these variables.
Just define them in constants.

Signed-off-by: Adam Litke <alitke@redhat.com>