### PR TITLE
Update ansible roles locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ COPY bin/run-v2v.sh /v2v.d/
 RUN setfacl -Rm u:apb:rwx /v2v.d
 
 COPY playbooks /opt/apb/actions
-COPY roles /opt/ansible/roles
-COPY templates /opt/ansible/templates
+COPY roles /opt/apb/actions/roles
+COPY templates /opt/apb/actions/templates
 
 USER apb


### PR DESCRIPTION
The APB base image changed the expected install location of ansible
roles.  Update the installed location in the Dockerfile.

Fixes #53

Signed-off-by: Adam Litke <alitke@redhat.com>