### PR TITLE
v2v: stop using appliance

### DIFF
--- a/images/v2v-job/Dockerfile
+++ b/images/v2v-job/Dockerfile
@@ -1,12 +1,9 @@
-FROM fedora:26
+FROM fedora:28
 
-
-RUN dnf install -y virt-v2v jq origin-clients libosinfo python-pip && dnf clean all
-RUN curl -L http://download.libguestfs.org/binaries/appliance/appliance-1.36.1.tar.xz | tar -C /usr/lib64/guestfs -xJf -
+RUN dnf install -y virt-v2v jq origin-clients libguestfs libguestfs-tools-c libvirt-daemon libvirt-daemon-config-network python-pip && dnf clean all
 RUN pip install j2cli
 
 ENV LIBGUESTFS_BACKEND=direct
-ENV LIBGUESTFS_PATH=/usr/lib64/guestfs/appliance
 
 WORKDIR /v2v.d
 ENTRYPOINT ["/v2v.d/job"]


### PR DESCRIPTION
We do not need to use appliance. We can instal libguestfs and
libvirt packages and use direct backend.

Fixes: https://github.com/ansibleplaybookbundle/import-vm-apb/issues/61