### PR TITLE
Update pod phase annotation

### DIFF
--- a/roles/import-from-url/defaults/main.yml
+++ b/roles/import-from-url/defaults/main.yml
@@ -5,5 +5,5 @@ disk_size_gb: 0  # auto-detect
 disk_bus_by_os_type:
   linux: virtio
   windows: sata
-import_status_path: .metadata.annotations.cdi\.kubevirt\.io/storage\.import\.pod\.phase
+import_status_path: .metadata.annotations.cdi\.kubevirt\.io/storage\.pod\.phase
 pvc_status_path: .status.phase


### PR DESCRIPTION
CDI changed the annotation of the pod phase when the import/clone/upload
controllers were refactored.  Update the APB to use the newer annotation
form.  The APB will now require cdi-1.2.0-alpha.1 or newer.

Signed-off-by: Adam Litke <alitke@redhat.com>