### PR TITLE
Add label to template so UI can tell this is a VM template

### DIFF
--- a/templates/linux-template.j2
+++ b/templates/linux-template.j2
@@ -8,6 +8,7 @@ metadata:
     tags: "kubevirt,ocp,template,linux,virtualmachine"
     iconClass: icon-other-linux
   labels:
+    template.cnv.io/type: vm
     kubevirt.io/os: rhel7.4
     miq.github.io/kubevirt-is-vm-template: "true"
     import-vm-apb/transaction_id: "{{ _apb_service_instance_id }}"

--- a/templates/windows-template.j2
+++ b/templates/windows-template.j2
@@ -8,6 +8,7 @@ metadata:
     tags: "kubevirt,ocp,template,windows,virtualmachine"
     iconClass: icon-windows
   labels:
+    template.cnv.io/type: vm
     kubevirt.io/os: win2k16
     miq.github.io/kubevirt-is-vm-template: "true"
     import-vm-apb/transaction_id: "{{ _apb_service_instance_id }}"


### PR DESCRIPTION
Please take a look at https://github.com/kubevirt/common-templates/pull/15#discussion_r218377253

UI needs this label to be able to differentiate between different types of templates